### PR TITLE
Fix problem when uploaded file have whitespace.

### DIFF
--- a/plugins/plg_editors_akmarkdown/assets/akmarkdown.js
+++ b/plugins/plg_editors_akmarkdown/assets/akmarkdown.js
@@ -164,7 +164,7 @@ var AKMarkdownClass = new Class({
 				return;
 			}
 
-			key = options.key + '/' + Math.round(date.getTime() / 1000) + '_' + file.name
+			key = options.key + '/' + Math.round(date.getTime() / 1000) + '_' + file.name.replace(/\s/g, '-');
 
 			fd.append('key', key);
 			fd.append('AWSAccessKeyId', options.apikey);


### PR DESCRIPTION
When there is whitespace in the name, then it is not transformed into link.
