### PR TITLE
Fix file name insert if there is . in the name

### DIFF
--- a/plugins/plg_editors_akmarkdown/assets/akmarkdown.js
+++ b/plugins/plg_editors_akmarkdown/assets/akmarkdown.js
@@ -190,8 +190,9 @@ var AKMarkdownClass = new Class({
 			bar.hide();
 			button.show();
 
-			var name = file.name.split('.').slice(-2)[0];
 			var ext = file.name.split('.').slice(-1)[0].toLowerCase();
+			var exp = new RegExp("\." + ext + "$", "g");
+			var name = file.name.replace(exp, '');
 
 			if($.inArray(ext, ['png', 'jpg', 'gif', 'jpeg']) >= 0) {
 				jInsertEditorText('\n<img alt="' + name + '" src="https://' + options.bucket + '.s3.amazonaws.com/' + key + '" class="img-polaroid" />', options.id);


### PR DESCRIPTION
There was a small problem If file have `.` in the name it did not take full name but only part from last `.`

To produce error upload something like `com_cobalt.v.8.987.zip` then only `987` will be taken as the name.
